### PR TITLE
feat(chisel-projects): add count-combinations module and make target

### DIFF
--- a/projects/chisel-practice/Makefile
+++ b/projects/chisel-practice/Makefile
@@ -39,11 +39,11 @@ pnrsevenseg.json: sevenseg.json
 sevenseg.fs: pnrsevenseg.json
 	$(APICULA) -d $(NEXTPNR_FAMILY) -o sevenseg.fs pnrsevenseg.json
 
-generated/projects/SevenSegTop.sv: ./src/main/scala/projects/CountCombinations.scala
+generated/projects/CountCombinationsTop.sv: ./src/main/scala/projects/CountCombinations.scala
 	$(SBT) "runMain projects.CountCombinationsVerilog"
 
-countcomb.json: generated/projects/SevenSegTop.sv
-	$(YOSYS) -p "read_verilog -sv generated/projects/SevenSegTop.sv; synth_gowin -json countcomb.json"
+countcomb.json: generated/projects/CountCombinationsTop.sv
+	$(YOSYS) -p "read_verilog -sv generated/projects/CountCombinationsTop.sv; synth_gowin -json countcomb.json"
 
 pnrcountcomb.json: countcomb.json
 	$(NEXTPNR) --freq $(NEXTPNR_FREQ) --json countcomb.json --write pnrcountcomb.json --device $(NEXTPNR_DEVICE) \

--- a/projects/chisel-practice/build.sbt
+++ b/projects/chisel-practice/build.sbt
@@ -5,6 +5,13 @@ lazy val root = (project in file("."))
     name := "chisel-practice",
     version := "0.1.0",
     scalaVersion := "2.13.12",
+    scalacOptions ++= Seq(
+      "-language:reflectiveCalls",
+      "-deprecation",
+      "-feature",
+      "-Xcheckinit",
+      "-Ymacro-annotations"
+    ),
     libraryDependencies ++= Seq(
       "org.chipsalliance" %% "chisel" % chiselVersion
     ),

--- a/projects/chisel-practice/src/main/scala/projects/CountCombinations.scala
+++ b/projects/chisel-practice/src/main/scala/projects/CountCombinations.scala
@@ -1,15 +1,65 @@
 package projects
 
+import blinky.SevenSegHexDisplay
 import util.ClockDivider
-import blinky.SevenSegTop
-import chisel3._
+import chisel3.util.log2Up
 import chisel3.util.Counter
+import chisel3.util.PopCount
+import chisel3._
 import circt.stage.ChiselStage
 
+class CountCombinations(numBits: Int) extends Module {
+  val io = IO(new Bundle {
+    val value = Input(UInt(numBits.W))
+    val count = Output(UInt(log2Up(numBits).W))
+  })
+
+  private val three = "b11".U
+  io.count :=
+    PopCount(
+      VecInit
+        .tabulate(numBits - 1) { i => (io.value(i + 1, i) === three) }
+        .asUInt
+    )
+}
+
+class CountCombinationsTopIO(numDigits: Int, numLeds: Int) extends Bundle {
+  val digit = Output(UInt(numDigits.W))
+  val segments = Output(UInt(8.W))
+}
+
+class CountCombinationsTop(
+    numBits: Int,
+    numDigits: Int,
+    numLeds: Int,
+    digitDivideBy: Int,
+    countFreq: Int,
+    countMax: Int
+) extends Module {
+  val io = IO(new CountCombinationsTopIO(numDigits, numLeds))
+  val invertedReset = ~reset.asBool
+  val dividedClock = withReset(reset = false.B) {
+    ClockDivider(clock, countFreq)
+  }
+  val (value, _) =
+    withClockAndReset(clock = dividedClock, reset = invertedReset) {
+      Counter(true.B, countMax)
+    }
+  val top = withReset(reset = invertedReset) {
+    Module(new CountCombinations(numBits))
+  }
+  val sevenseg = withReset(reset = invertedReset) {
+    Module(new SevenSegHexDisplay(numDigits, digitDivideBy))
+  }
+  io.digit <> sevenseg.io.digitSelect
+  io.segments <> sevenseg.io.segments
+  sevenseg.io.value := top.io.count
+  top.io.value := value
+}
 
 object CountCombinationsVerilog extends App {
   ChiselStage.emitSystemVerilogFile(
-    new SevenSegTop(4, 6, 270_000, 2_700_000, 0xffff),
+    new CountCombinationsTop(8, 4, 6, 135_000, 5_000_000, 0xff),
     args = Array("--target-dir", "generated/projects"),
     firtoolOpts = Array(
       "--disable-all-randomization",


### PR DESCRIPTION
This module computes the number of two consequtive ones in a arbitrarily wide number.