### PR TITLE
feat(chisel-practice): add parallel counter module

### DIFF
--- a/projects/chisel-practice/boards/tangnano9k.cst
+++ b/projects/chisel-practice/boards/tangnano9k.cst
@@ -3,12 +3,14 @@
 // https://github.com/YosysHQ/apicula/blob/master/examples/tangnano9k.cst
 // Part Number: GW1NR-LV9QN88PC6/I5
 
-IO_LOC "io_led[0]" 10;
-IO_LOC "io_led[1]" 11;
-IO_LOC "io_led[2]" 13;
-IO_LOC "io_led[3]" 14;
-IO_LOC "io_led[4]" 15;
-IO_LOC "io_led[5]" 16;
+IO_LOC "io_led[0]" 76;
+IO_LOC "io_led[1]" 38;
+IO_LOC "io_led[2]" 37;
+IO_LOC "io_led[3]" 27;
+IO_LOC "io_led[4]" 51;
+IO_LOC "io_led[5]" 42;
+IO_LOC "io_led[6]" 40;
+IO_LOC "io_led[7]" 34;
 
 IO_LOC "io_digit[0]" 75;
 IO_LOC "io_digit[1]" 72;

--- a/projects/chisel-practice/src/main/scala/projects/CountCombinations.scala
+++ b/projects/chisel-practice/src/main/scala/projects/CountCombinations.scala
@@ -25,6 +25,7 @@ class CountCombinations(numBits: Int) extends Module {
 
 class CountCombinationsTopIO(numDigits: Int, numLeds: Int) extends Bundle {
   val digit = Output(UInt(numDigits.W))
+  val led = Output(UInt(numLeds.W))
   val segments = Output(UInt(8.W))
 }
 
@@ -55,11 +56,13 @@ class CountCombinationsTop(
   io.segments <> sevenseg.io.segments
   sevenseg.io.value := top.io.count
   top.io.value := value
+  io.led := value
 }
 
 object CountCombinationsVerilog extends App {
   ChiselStage.emitSystemVerilogFile(
-    new CountCombinationsTop(8, 4, 6, 135_000, 5_000_000, 0xff),
+    new CountCombinationsTop(8 /* numBits */, 4 /* numDigits */,
+      8 /* numLeds */, 135_000, 5_000_000, 256),
     args = Array("--target-dir", "generated/projects"),
     firtoolOpts = Array(
       "--disable-all-randomization",

--- a/projects/chisel-practice/src/main/scala/projects/ParallelCarryCounter.scala
+++ b/projects/chisel-practice/src/main/scala/projects/ParallelCarryCounter.scala
@@ -1,0 +1,32 @@
+package projects
+
+import chisel3.util.log2Up
+import chisel3.util.Counter
+import chisel3.util.PopCount
+import chisel3._
+import circt.stage.ChiselStage
+
+class ParallelCarryCounter(maxValue: Int) extends Module {
+  val bitWidth: Int = log2Up(maxValue)
+
+  val io = IO(new Bundle {
+    val count = Output(UInt(bitWidth.W))
+    val overflow = Output(Bool())
+  })
+
+  val value = RegInit(VecInit(Seq.fill(bitWidth)(false.B)))
+
+  value(0) := value(0) ^ 1.U(1.W)
+  for (i <- 1 until bitWidth) {
+    value(i) := value(i) ^ value
+      .slice(0, i)
+      .map(_.asBool)
+      .reduce(_ & _)
+  }
+
+  io.count := value.asUInt
+  io.overflow := (value.asUInt === (maxValue - 1).U(bitWidth.W))
+  when(io.overflow) {
+    for (i <- 0 until bitWidth) { value(i) := false.B }
+  }
+}

--- a/projects/chisel-practice/src/test/scala/projects/ParallelCarryCounter.scala
+++ b/projects/chisel-practice/src/test/scala/projects/ParallelCarryCounter.scala
@@ -1,0 +1,46 @@
+package projects.tests
+
+import projects.ParallelCarryCounter
+import chisel3._
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+
+class ParallelCarryCounterTester
+    extends AnyFlatSpec
+    with ChiselScalatestTester {
+  "ParallelCarryCounter" should "count up to 2" in {
+    test(new ParallelCarryCounter(2)) { dut =>
+      dut.io.count.expect(0.U)
+      dut.io.overflow.expect(false.B)
+      dut.clock.step(1)
+      dut.io.count.expect(1.U)
+      dut.io.overflow.expect(true.B)
+      dut.clock.step(1)
+      dut.io.count.expect(0.U)
+      dut.io.overflow.expect(false.B)
+    }
+  }
+
+  "ParallelCarryCounter" should "count up to 5" in {
+    test(new ParallelCarryCounter(5)).withAnnotations(Seq(WriteVcdAnnotation)) {
+      dut =>
+        dut.io.count.expect(0.U)
+        dut.io.overflow.expect(false.B)
+        dut.clock.step(1)
+        dut.io.count.expect(1.U)
+        dut.io.overflow.expect(false.B)
+        dut.clock.step(1)
+        dut.io.count.expect(2.U)
+        dut.io.overflow.expect(false.B)
+        dut.clock.step(1)
+        dut.io.count.expect(3.U)
+        dut.io.overflow.expect(false.B)
+        dut.clock.step(1)
+        dut.io.count.expect(4.U)
+        dut.io.overflow.expect(true.B)
+        dut.clock.step(1)
+        dut.io.count.expect(0.U)
+        dut.io.overflow.expect(false.B)
+    }
+  }
+}


### PR DESCRIPTION
Add led indicators to the board physical constraints file. Display current number in count-combinations via the provided leds.