### PR TITLE
fix(countcomb): make module function correctly

### DIFF
--- a/projects/chisel-practice/src/main/scala/projects/CountCombinations.scala
+++ b/projects/chisel-practice/src/main/scala/projects/CountCombinations.scala
@@ -15,12 +15,24 @@ class CountCombinations(numBits: Int) extends Module {
   })
 
   private val three = "b11".U
+
+  val areOnes =
+    VecInit
+      .tabulate(numBits - 1) { i =>
+        val currentBits = io.value(i + 1, i)
+        currentBits === three
+      };
+
+  val utilVec = VecInit(0.U(numBits.W).asBools)
+  for (i <- 0 until numBits - 1) {
+    utilVec(i) := (if (i == 0) { areOnes(i) }
+                   else {
+                     !utilVec(i - 1) && areOnes(i)
+                   })
+  }
+
   io.count :=
-    PopCount(
-      VecInit
-        .tabulate(numBits - 1) { i => (io.value(i + 1, i) === three) }
-        .asUInt
-    )
+    PopCount(utilVec.asUInt)
 }
 
 class CountCombinationsTopIO(numDigits: Int, numLeds: Int) extends Bundle {

--- a/projects/chisel-practice/src/test/scala/projects/CountCombinations.scala
+++ b/projects/chisel-practice/src/test/scala/projects/CountCombinations.scala
@@ -6,10 +6,10 @@ import chiseltest._
 import org.scalatest.flatspec.AnyFlatSpec
 
 class CountCombinationsTester extends AnyFlatSpec with ChiselScalatestTester {
-  "CountCombinations of 0b11 in 0b11111111" should "be equal to 7" in {
+  "CountCombinations of 0b11 in 0b11111111" should "be equal to 4" in {
     test(new CountCombinations(8)) { dut =>
       dut.io.value.poke("b11111111".U)
-      dut.io.count.expect(7.U)
+      dut.io.count.expect(4.U)
     }
   }
 
@@ -17,6 +17,19 @@ class CountCombinationsTester extends AnyFlatSpec with ChiselScalatestTester {
     test(new CountCombinations(8)) { dut =>
       dut.io.value.poke("b00000000".U)
       dut.io.count.expect(0.U)
+    }
+  }
+  
+  "CountCombinations of 0b11 in 0b00000111" should "be equal to 1" in {
+    test(new CountCombinations(8)) { dut =>
+      dut.io.value.poke("b00000111".U)
+      dut.io.count.expect(1.U)
+    }
+  }
+  "CountCombinations of 0b11 in 0b11100111" should "be equal to 2" in {
+    test(new CountCombinations(8)) { dut =>
+      dut.io.value.poke("b11100111".U)
+      dut.io.count.expect(2.U)
     }
   }
 }


### PR DESCRIPTION
Makes the module not count duplicate consequtive bits.